### PR TITLE
Remove sincedb entry on file rotation or removal.

### DIFF
--- a/beaver/__init__.py
+++ b/beaver/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '36.2.1-affirm-2.0'
+__version__ = '36.2.1-affirm-2.1'

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -1,0 +1,55 @@
+# ~*~ encoding: utf-8 ~*~
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+import mock
+import tempfile
+
+from beaver.config import BeaverConfig
+from beaver.worker.tail import  Tail
+import sqlite3
+
+class TestTail(unittest.TestCase):
+
+    def setUp(self):
+        self.sincedb_path = tempfile.NamedTemporaryFile(delete=True).name
+        self.filename = tempfile.NamedTemporaryFile(delete=True).name
+
+        beaver_config = self._get_config()
+        beaver_config.set('sincedb_path', self.sincedb_path)
+        self.tail = Tail(self.filename, None, beaver_config=beaver_config)
+
+    def _get_config(self, **kwargs):
+        empty_conf = tempfile.NamedTemporaryFile(delete=True)
+        return BeaverConfig(mock.Mock(config=empty_conf.name, **kwargs))
+
+    def _test_close_parameterized_remove_db_entry(self, remove_db_entry):
+        # Fid is needed but instantiated during a run, so we 'mock'.
+        self.tail._fid = 'fid'
+        # Update the position so we have an entry.
+        self.assertTrue(self.tail._sincedb_update_position(20, force_update=True))
+        # active is also set during a run, but we must force it.
+        self.tail.active = True
+
+        # close with the parameterized remove_db_entry and return the number of results.
+        self.tail.close(remove_db_entry=remove_db_entry)
+        conn = sqlite3.connect(self.sincedb_path, isolation_level=None)
+        cursor = conn.cursor()
+        cursor.execute('select * from sincedb where filename = :filename', {
+            'filename': self.filename
+        })
+        return cursor.fetchall()
+
+    def test_close_with_remove_db_entry(self):
+        # With remove entry, results should be 0 since db entry is removed.
+        results = self._test_close_parameterized_remove_db_entry(True)
+        self.assertEquals(len(results), 0)
+
+
+    def test_close_without_remove_db_entry(self):
+        # Without remove entry, results should be 1.
+        results = self._test_close_parameterized_remove_db_entry(False)
+        self.assertEquals(len(results), 1)


### PR DESCRIPTION
This removes the db entries after a file closes or there's log rotation (there might be a few cases that are missed, however).

Current sincedb after running for 20 hours:

![screen shot 2017-12-12 at 11 51 44 am](https://user-images.githubusercontent.com/615126/33905298-07b92744-df33-11e7-900b-552bbaa081ea.png)
 
@gregsterin 